### PR TITLE
Added a title to the honeypot form field

### DIFF
--- a/Form/Extension/Spam/Type/FormTypeHoneypotExtension.php
+++ b/Form/Extension/Spam/Type/FormTypeHoneypotExtension.php
@@ -65,6 +65,8 @@ class FormTypeHoneypotExtension extends AbstractTypeExtension
                 );
             }
 
+            $formOptions['attr']['title'] = '';
+
             $factory = $form->getConfig()->getAttribute('honeypot_factory');
             $honeypotForm = $factory->createNamed($options['honeypot_field'], 'text', null, $formOptions);
 


### PR DESCRIPTION
Hello!
Since the honeypot field has no label, I added a title attribute to make accessibility validators happy.

Thanks