### PR TITLE
Implemented cookie protection

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -44,6 +44,17 @@ class Configuration implements ConfigurationInterface
                             ->defaultValue('Form fields are invalid')->end()
                     ->end()
                 ->end()
+            
+            
+                ->arrayNode('cookie')
+                    ->canBeDisabled()
+                    ->children()
+                        ->scalarNode('name')->defaultValue('antispam')->end()
+                        ->booleanNode('global')->defaultFalse()->end()
+                        ->scalarNode('message')
+                            ->defaultValue('Something is wrong, please try again')->end()
+                    ->end()
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/IsometriksSpamExtension.php
+++ b/DependencyInjection/IsometriksSpamExtension.php
@@ -25,6 +25,7 @@ class IsometriksSpamExtension extends Extension
 
         $this->processTimedConfig($config['timed'], $container, $loader);
         $this->processHoneypotConfig($config['honeypot'], $container, $loader);
+        $this->processCookieConfig($config['cookie'], $container, $loader);
     }
 
     private function processTimedConfig(array $config, ContainerBuilder $container, XmlFileLoader $loader)
@@ -57,6 +58,22 @@ class IsometriksSpamExtension extends Extension
             'field' => $config['field'],
             'use_class' => $config['use_class'],
             'hide_class' => $config['hide_class'],
+            'global' => $config['global'],
+            'message' => $config['message'],
+        ));
+    }
+
+    private function processCookieConfig(array $config, ContainerBuilder $container, XmlFileLoader $loader)
+    {
+        if (!$this->isConfigEnabled($container, $config)) {
+            return;
+        }
+
+        $loader->load('cookie.xml');
+
+        $definition = $container->getDefinition('isometriks_spam.form.extension.type.cookie');
+        $definition->addArgument(array(
+            'name' => $config['name'],
             'global' => $config['global'],
             'message' => $config['message'],
         ));

--- a/EventListener/KernelResponseListener.php
+++ b/EventListener/KernelResponseListener.php
@@ -5,7 +5,6 @@ namespace Isometriks\Bundle\SpamBundle\EventListener;
 
 use Isometriks\Bundle\SpamBundle\Form\Extension\Spam\Provider\CookieProvider;
 use Symfony\Component\HttpFoundation\Cookie;
-use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 
 class KernelResponseListener
@@ -28,6 +27,7 @@ class KernelResponseListener
                 $responseEvent->getResponse()->headers->setCookie($cookie);
             } else if ($cookieData['mode'] == 'remove') {
                 $responseEvent->getResponse()->headers->removeCookie($cookieData['name']);
+                $responseEvent->getResponse()->headers->clearCookie($cookieData['name']);
                 $this->cookieProvider->removeCookieSettings();
             }
         }        

--- a/EventListener/KernelResponseListener.php
+++ b/EventListener/KernelResponseListener.php
@@ -1,0 +1,35 @@
+<?php
+
+
+namespace Isometriks\Bundle\SpamBundle\EventListener;
+
+use Isometriks\Bundle\SpamBundle\Form\Extension\Spam\Provider\CookieProvider;
+use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+
+class KernelResponseListener
+{
+    /** @var CookieProvider */
+    private $cookieProvider;
+    
+    public function __construct($cookieProvider)
+    {
+        $this->cookieProvider = $cookieProvider;
+    }
+
+    public function onKernelResponse(FilterResponseEvent $responseEvent)
+    {
+        $cookieData = $this->cookieProvider->getCookieSettings();
+        if ($cookieData) {
+            if($cookieData['mode'] == 'add') {
+                $cookie = new Cookie($cookieData['name'], 1);
+                
+                $responseEvent->getResponse()->headers->setCookie($cookie);
+            } else if ($cookieData['mode'] == 'remove') {
+                $responseEvent->getResponse()->headers->removeCookie($cookieData['name']);
+                $this->cookieProvider->removeCookieSettings();
+            }
+        }        
+    }
+}

--- a/Form/Extension/Spam/EventListener/CookieValidationListener.php
+++ b/Form/Extension/Spam/EventListener/CookieValidationListener.php
@@ -1,0 +1,64 @@
+<?php
+
+
+namespace Isometriks\Bundle\SpamBundle\Form\Extension\Spam\EventListener;
+
+use Isometriks\Bundle\SpamBundle\Form\Extension\Spam\Provider\CookieProvider;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class CookieValidationListener implements EventSubscriberInterface
+{
+    private $cookieProvider;
+    private $request;
+    private $translator;
+    private $translationDomain;
+    private $cookieName;
+    private $errorMessage;
+
+    public function __construct(CookieProvider $cookieProvider,
+                                Request $request,
+                                TranslatorInterface $translator,
+                                $translationDomain,
+                                $cookieName,
+                                $errorMessage)
+    {
+        $this->cookieProvider = $cookieProvider;
+        $this->request = $request;
+        $this->translator = $translator;
+        $this->translationDomain = $translationDomain;
+        $this->cookieName = $cookieName;
+        $this->errorMessage = $errorMessage;
+    }
+
+    public function preSubmit(FormEvent $event)
+    {
+        $form = $event->getForm();
+        
+        if($form->isRoot() && $form->getConfig()->getOption('compound') && !$this->request->cookies->get($this->cookieName)) {
+            $errorMessage = $this->errorMessage;
+
+            if (null !== $this->translator) {
+                $errorMessage = $this->translator->trans($errorMessage, array(), $this->translationDomain);
+            }
+
+            $form->addError(new FormError($errorMessage));
+            
+            return;
+        }
+        
+        $this->cookieProvider->removeAntispamCookie($this->cookieName);
+    }  
+    
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            FormEvents::PRE_SUBMIT => 'preSubmit',
+        );
+    }
+}

--- a/Form/Extension/Spam/Provider/CookieProvider.php
+++ b/Form/Extension/Spam/Provider/CookieProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+
+namespace Isometriks\Bundle\SpamBundle\Form\Extension\Spam\Provider;
+
+use Symfony\Component\HttpFoundation\Session\Session;
+
+class CookieProvider
+{
+    private $session;
+    
+    public function __construct(Session $session)
+    {
+        $this->session = $session;
+    }
+    
+    public function setAntispamCookie($cookieName)
+    {
+        $this->session->set('antispam_cookie', array('mode' => 'add', 'name' => $cookieName));
+    }
+
+    public function removeAntispamCookie($cookieName)
+    {
+        $this->session->set('antispam_cookie', array('mode' => 'remove', 'name' => $cookieName));        
+    }
+
+    public function getCookieSettings()
+    {
+        return $this->session->get('antispam_cookie');
+    }
+
+    public function removeCookieSettings()
+    {
+        $this->session->remove('antispam_cookie');   
+    }
+}

--- a/Form/Extension/Spam/Type/FormTypeCookieExtension.php
+++ b/Form/Extension/Spam/Type/FormTypeCookieExtension.php
@@ -1,0 +1,82 @@
+<?php
+
+
+namespace Isometriks\Bundle\SpamBundle\Form\Extension\Spam\Type;
+
+use Isometriks\Bundle\SpamBundle\Form\Extension\Spam\EventListener\CookieValidationListener;
+use Isometriks\Bundle\SpamBundle\Form\Extension\Spam\Provider\CookieProvider;
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class FormTypeCookieExtension extends AbstractTypeExtension
+{
+    private $cookieProvider;
+    private $request;
+    private $session;
+    private $translator;
+    private $translationDomain;
+    private $defaults;
+
+    public function __construct(CookieProvider $cookieProvider,
+                                Request $request,
+                                Session $session, 
+                                TranslatorInterface $translator,
+                                $translationDomain,
+                                array $defaults)
+    {
+        $this->cookieProvider = $cookieProvider;
+        $this->request = $request;
+        $this->session = $session;
+        $this->translator = $translator;
+        $this->translationDomain = $translationDomain;
+        $this->defaults = $defaults;
+    }
+    
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        if (!$options['cookie']) {
+            return;
+        }
+
+        $builder
+            ->addEventSubscriber(new CookieValidationListener(
+                $this->cookieProvider,
+                $this->request,
+                $this->translator,
+                $this->translationDomain,
+                $options['cookie_name'],
+                $options['cookie_message']
+            ));
+    }
+
+    public function finishView(FormView $view, FormInterface $form, array $options)
+    {
+        $this->cookieProvider->setAntispamCookie($options['cookie_name']);
+    }
+
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $this->configureOptions($resolver);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'cookie' => $this->defaults['global'],
+            'cookie_name' => $this->defaults['name'],
+            'cookie_message' => $this->defaults['message'],
+        ));
+    }
+
+    public function getExtendedType()
+    {
+        return 'form';
+    }
+}

--- a/Resources/config/cookie.xml
+++ b/Resources/config/cookie.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="isometriks_spam.form.extension.type.cookie.class">Isometriks\Bundle\SpamBundle\Form\Extension\Spam\Type\FormTypeCookieExtension</parameter>
+        <parameter key="isometriks_spam.form.extension.provider.cookie.class">Isometriks\Bundle\SpamBundle\Form\Extension\Spam\Provider\CookieProvider</parameter>
+        <parameter key="isometriks_spam.event_listener.kernel_response.class">Isometriks\Bundle\SpamBundle\EventListener\KernelResponseListener</parameter>
+    </parameters>
+
+    <services>
+        <service id="isometriks_spam.form.extension.provider.cookie" class="%isometriks_spam.form.extension.provider.cookie.class%">
+            <argument type="service" id="session" />
+        </service>
+        
+        <service id="isometriks_spam.form.extension.type.cookie" class="%isometriks_spam.form.extension.type.cookie.class%" scope="request">
+            <tag name="form.type_extension" alias="form" />
+            <argument type="service" id="isometriks_spam.form.extension.provider.cookie" />
+            <argument type="service" id="request" />
+            <argument type="service" id="session" />
+            <argument type="service" id="translator.default" />
+            <argument>%validator.translation_domain%</argument>
+        </service>
+        
+        <service id="isometriks_spam.exception_listener" class="%isometriks_spam.event_listener.kernel_response.class%">
+            <tag name="kernel.event_listener" event="kernel.response" method="onKernelResponse" />
+            <argument type="service" id="isometriks_spam.form.extension.provider.cookie" />
+        </service>
+    </services>
+</container>


### PR DESCRIPTION
Spam bots do not use cookies (see http://impresswithwp.com/3-ways-fight-comment-spam-wordpress-website/, https://www.thoughtco.com/solutions-to-protect-web-forms-from-spam-3467469) so this could be used as an another protection method.
Unfortunately I have no possibility to implement this for Symfony 3.x so I've implemented this method on Symfony 2.8.