### PR TITLE
Make symfony translator optional

### DIFF
--- a/Form/Extension/Spam/EventListener/HoneypotValidationListener.php
+++ b/Form/Extension/Spam/EventListener/HoneypotValidationListener.php
@@ -15,7 +15,7 @@ class HoneypotValidationListener implements EventSubscriberInterface
     private $fieldName;
     private $errorMessage;
 
-    public function __construct(TranslatorInterface $translator,
+    public function __construct(TranslatorInterface $translator = null,
                                 $translationDomain,
                                 $fieldName,
                                 $errorMessage)

--- a/Form/Extension/Spam/EventListener/TimedSpamValidationListener.php
+++ b/Form/Extension/Spam/EventListener/TimedSpamValidationListener.php
@@ -18,7 +18,7 @@ class TimedSpamValidationListener implements EventSubscriberInterface
     private $options;
 
     public function __construct(TimedSpamProviderInterface $timeProvider,
-                                TranslatorInterface $translator,
+                                TranslatorInterface $translator = null,
                                 $translationDomain,
                                 $errorMessage,
                                 $options)

--- a/Form/Extension/Spam/Type/FormTypeHoneypotExtension.php
+++ b/Form/Extension/Spam/Type/FormTypeHoneypotExtension.php
@@ -19,7 +19,7 @@ class FormTypeHoneypotExtension extends AbstractTypeExtension
     private $translationDomain;
     private $defaults;
 
-    public function __construct(TranslatorInterface $translator,
+    public function __construct(TranslatorInterface $translator = null,
                                 $translationDomain,
                                 array $defaults)
     {

--- a/Form/Extension/Spam/Type/FormTypeTimedSpamExtension.php
+++ b/Form/Extension/Spam/Type/FormTypeTimedSpamExtension.php
@@ -21,7 +21,7 @@ class FormTypeTimedSpamExtension extends AbstractTypeExtension
     private $defaults;
 
     public function __construct(TimedSpamProviderInterface $timeProvider,
-                                TranslatorInterface $translator,
+                                TranslatorInterface $translator = null,
                                 $translationDomain,
                                 array $defaults)
     {

--- a/Resources/config/honeypot.xml
+++ b/Resources/config/honeypot.xml
@@ -7,7 +7,7 @@
     <services>
         <service id="isometriks_spam.form.extension.type.honeypot" class="Isometriks\Bundle\SpamBundle\Form\Extension\Spam\Type\FormTypeHoneypotExtension">
             <tag name="form.type_extension" extended-type="Symfony\Component\Form\Extension\Core\Type\FormType" />
-            <argument type="service" id="translator" />
+            <argument type="service" id="translator" on-invalid="ignore" />
             <argument>%validator.translation_domain%</argument>
         </service>
     </services>

--- a/Resources/config/timed.xml
+++ b/Resources/config/timed.xml
@@ -12,7 +12,7 @@
         <service id="isometriks_spam.form.extension.type.timed_spam" class="Isometriks\Bundle\SpamBundle\Form\Extension\Spam\Type\FormTypeTimedSpamExtension">
             <tag name="form.type_extension" extended-type="Symfony\Component\Form\Extension\Core\Type\FormType" />
             <argument type="service" id="isometriks_spam.form.extension.provider.timed_spam" />
-            <argument type="service" id="translator" />
+            <argument type="service" id="translator" on-invalid="ignore" />
             <argument>%validator.translation_domain%</argument>
         </service>
     </services>


### PR DESCRIPTION
There are basic checks (null !== $this->translator) for translation service in source code but technically translator is required but not specified in package dependencies. Also, for some projects is not really needed.
Make it really optional.