### PR TITLE
Add autocomplete, tabindex, and aria attributes to the honeypot field

### DIFF
--- a/Form/Extension/Spam/Type/FormTypeHoneypotExtension.php
+++ b/Form/Extension/Spam/Type/FormTypeHoneypotExtension.php
@@ -55,16 +55,18 @@ class FormTypeHoneypotExtension extends AbstractTypeExtension
                 'mapped' => false,
                 'label' => false,
                 'required' => false,
+                'attr' => [
+                    'aria-hidden' => 'true',
+                    'aria-label' => $options['honeypot_field'],
+                    'autocomplete' => 'off',
+                    'tabindex' => '-1',
+                ],
             ];
 
             if ($options['honeypot_use_class']) {
-                $formOptions['attr'] = [
-                    'class' => $options['honeypot_hide_class'],
-                ];
+                $formOptions['attr']['class'] = $options['honeypot_hide_class'];
             } else {
-                $formOptions['attr'] = [
-                    'style' => 'display:none',
-                ];
+                $formOptions['attr']['style'] = 'display:none';
             }
 
             $factory = $form->getConfig()->getAttribute('honeypot_factory');


### PR DESCRIPTION
This merge provides to accessibility/UX improvements:

- Add [attribute tabindex="-1"](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex) to the honeypot field so that users navigating with the tab key won't stop on the field.

> A negative value (usually tabindex="-1") means that the element is not reachable via sequential keyboard navigation, but could be focused with Javascript or visually by clicking with the mouse.

- Add [attribute autocomplete="off"](https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion) to the honeypot form to prevent browsers from auto-filling the field.

> As website author, you might prefer that the browser not remember the values for such fields, even if the browser's autocomplete feature is enabled.

- Set the ARIA labels necessary for assistive technologies to recognize the field and to ignore it.