### PR TITLE
Fix time protection after validation errors

### DIFF
--- a/Form/Extension/Spam/EventListener/TimedSpamValidationListener.php
+++ b/Form/Extension/Spam/EventListener/TimedSpamValidationListener.php
@@ -54,10 +54,23 @@ class TimedSpamValidationListener implements EventSubscriberInterface
         $this->timeProvider->removeFormTime($form->getName());
     }
 
+    public function postSubmit(FormEvent $event): void
+    {
+        $form = $event->getForm();
+
+        if ($form->isRoot() &&
+            $form->getConfig()->getOption('compound') &&
+            !$form->isValid()) {
+            // If the form has errors, set the time again
+            $this->timeProvider->generateFormTime($form->getName());
+        }
+    }
+
     public static function getSubscribedEvents(): array
     {
         return array(
             FormEvents::PRE_SUBMIT => 'preSubmit',
+            FormEvents::POST_SUBMIT => 'postSubmit',
         );
     }
 }


### PR DESCRIPTION
Fix issue with time protection that prevents form re-submitting after validation errors.

As is written in the README:
_A side affect of this spam prevention is that you won't be able to refresh a page to resubmit data UNLESS the view is rendered again $form->createView() This is because the event listener removes the start time of the form and when it can't find it, will cause the form to be invalid._

If the form is submitted and there are some validation errors, the time protection prevents submitting it again after fixing the form values. It would give a time error even though the form is submitted within the min and max seconds.

This change is adding the start time again on POST_SUBMIT if error is not valid.