### PR TITLE
Add functional tests + fix deprecation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.idea
 /composer.lock
 /vendor
+/.phpunit.result.cache

--- a/Form/Extension/Spam/Type/FormTypeTimedSpamExtension.php
+++ b/Form/Extension/Spam/Type/FormTypeTimedSpamExtension.php
@@ -60,7 +60,7 @@ class FormTypeTimedSpamExtension extends AbstractTypeExtension
         }
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(array(
             'timed_spam' => $this->defaults['global'],

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,12 @@
         "symfony/http-foundation": "^4.4 || ^5.4 || ^6.0",
         "symfony/http-kernel": "^4.4 || ^5.4 || ^6.0",
         "symfony/options-resolver": "^4.4 || ^5.4 || ^6.0",
-        "symfony/translation-contracts": "1.0 || ^2.0 || ^3.0"
+        "symfony/translation-contracts": "1.0 || ^2.0 || ^3.0",
+        "symfony/framework-bundle": "^4.4 || ^5.4 || ^6.0"
+    },
+    "require-dev": {
+        "symfony/phpunit-bridge": "^4.4 || ^5.4 || ^6.0",
+        "symfony/yaml": "^4.4 || ^5.4 || ^6.3"
     },
     "authors": [
         {
@@ -26,6 +31,9 @@
         }
     ],
     "autoload": {
-        "psr-4": { "Isometriks\\Bundle\\SpamBundle\\": "" }
+        "psr-4": {
+            "Isometriks\\Bundle\\SpamBundle\\": "",
+            "Isometriks\\Bundle\\SpamBundle\\Tests\\": "tests/"
+        }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- https://phpunit.readthedocs.io/en/latest/configuration.html -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         convertDeprecationsToExceptions="false"
+>
+    <php>
+        <ini name="display_errors" value="1" />
+        <ini name="error_reporting" value="-1" />
+        <server name="KERNEL_CLASS" value="Isometriks\Bundle\SpamBundle\Tests\fixtures\TestKernel"/>
+        <server name="APP_ENV" value="test" force="true" />
+        <server name="SHELL_VERBOSITY" value="-1" />
+        <server name="SYMFONY_PHPUNIT_REMOVE" value="" />
+        <server name="SYMFONY_PHPUNIT_VERSION" value="9.5" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Bundle Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </coverage>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
+</phpunit>

--- a/tests/HoneyPotTest.php
+++ b/tests/HoneyPotTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Isometriks\Bundle\SpamBundle\Tests;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+
+class HoneyPotTest extends KernelTestCase
+{
+    /**
+     * @dataProvider provideValidationShouldPass
+     */
+    public function testValidationShouldPass($data, $formOptions): void
+    {
+        self::bootKernel();
+
+        $formBuilder = self::getContainer()->get('form.factory.custom')->createBuilder(FormType::class, null, $formOptions);
+        foreach (array_keys($data) as $key) {
+            $formBuilder->add($key);
+        }
+        $form = $formBuilder->getForm();
+        $form->submit($data);
+        $this->assertEquals(true, $form->isValid());
+        $this->assertEmpty($form->getErrors());
+    }
+
+    public function provideValidationShouldPass()
+    {
+        return [
+            'no_honeypot' => [
+                [
+                    'email' => 'foo@email.com',
+                    'phone' => '0000000000',
+                ],
+                [
+                    'honeypot' => false,
+                ]
+            ],
+            'no_honeypot_with_field' => [
+                [
+                    'email' => 'foo@email.com',
+                    'phone' => '0000000000',
+                ],
+                [
+                    'honeypot' => false,
+                    'honeypot_field' => 'phone',
+                ]
+            ],
+            'honeypot_on_phone' => [
+                [
+                    'email' => 'foo@email.com',
+                    'phone' => '',
+                ],
+                [
+                    'honeypot' => true,
+                    'honeypot_field' => 'phone',
+                ]
+            ],
+            'honeypot_on_email' => [
+                [
+                    'email' => '',
+                    'phone' => '0000000000',
+                ],
+                [
+                    'honeypot' => true,
+                    'honeypot_field' => 'email',
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider provideValidationShouldFail
+     */
+    public function testValidationShouldFail($data, $formOptions, $expectedMessage = 'Form fields are invalid'): void
+    {
+        self::bootKernel();
+
+        $formBuilder = self::getContainer()->get('form.factory.custom')->createBuilder(FormType::class, null, $formOptions);
+        foreach (array_keys($data) as $key) {
+            $formBuilder->add($key);
+        }
+        $form = $formBuilder->getForm();
+        $form->submit($data);
+        $this->assertFalse($form->isValid());
+        $this->assertNotEmpty($form->getErrors());
+        $this->assertEquals($expectedMessage, $form->getErrors()->offsetGet(0)->getMessage());
+    }
+
+    public function provideValidationShouldFail()
+    {
+        return [
+            'honeypot_on_phone' => [
+                [
+                    'email' => 'foo@email.com',
+                    'phone' => '0000000000',
+                ],
+                [
+                    'honeypot' => true,
+                    'honeypot_field' => 'phone',
+                ]
+            ],
+            'honeypot_field_not_submitted' => [
+                [
+                    'email' => 'foo@email.com',
+                    'phone' => '0000000000',
+                ],
+                [
+                    'honeypot' => true,
+                    'honeypot_field' => 'foo',
+                ],
+            ],
+            'honeypot_field_null' => [
+                [
+                    'email' => 'foo@email.com',
+                    'phone' => null,
+                ],
+                [
+                    'honeypot' => true,
+                    'honeypot_field' => 'phone',
+                ]
+            ],
+            'honeypot_with_error_message' => [
+                [
+                    'email' => 'ezaezae',
+                    'phone' => '0000000000',
+                ],
+                [
+                    'honeypot' => true,
+                    'honeypot_field' => 'email',
+                    'honeypot_message' => 'We detected a strange behaviour in your form submission. Please try again.',
+                ],
+                'We detected a strange behaviour in your form submission. Please try again.'
+            ],
+        ];
+    }
+}

--- a/tests/TimedSpamTest.php
+++ b/tests/TimedSpamTest.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace Isometriks\Bundle\SpamBundle\Tests;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionFactory;
+use Symfony\Component\HttpFoundation\Session\Storage\MockFileSessionStorageFactory;
+
+class TimedSpamTest extends KernelTestCase
+{
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $sessionFactory = new MockFileSessionStorageFactory();
+        $request = new Request();
+        $request->setSession(new Session($sessionFactory->createStorage(null)));
+        self::getContainer()->get('request_stack')->push($request);
+    }
+
+    /**
+     * @dataProvider provideValidationShouldPass
+     */
+    public function testValidationShouldPass($data, $formOptions, $sleep = 0): void
+    {
+        $formBuilder = self::getContainer()->get('form.factory.custom')->createBuilder(FormType::class, null, $formOptions);
+        foreach (array_keys($data) as $key) {
+            $formBuilder->add($key);
+        }
+        $form = $formBuilder->getForm();
+        $form->createView();
+        if ($sleep > 0) {
+            sleep($sleep);
+        }
+        $form->submit($data);
+        $this->assertTrue($form->isValid());
+        $this->assertEmpty($form->getErrors());
+    }
+
+    public function provideValidationShouldPass()
+    {
+        return [
+            'no_timed_spam' => [
+                [
+                    'email' => 'foo@email.com',
+                    'phone' => '0000000000',
+                ],
+                [
+                    'timed_spam' => false,
+                ]
+            ],
+            'no_timed_spam_with_options' => [
+                [
+                    'email' => 'foo@email.com',
+                    'phone' => '0000000000',
+                ],
+                [
+                    'timed_spam' => false,
+                    'timed_spam_min' => 3,
+                    'timed_spam_max' => 40,
+                    'timed_spam_message' => 'Please wait 3 seconds before submitting',
+                ]
+            ],
+            'timed_spam_min_0' => [
+                [
+                    'email' => 'foo@email.com',
+                    'phone' => '',
+                ],
+                [
+                    'timed_spam' => true,
+                    'timed_spam_min' => 0,
+                ]
+            ],
+            'timed_spam_min_1' => [
+                [
+                    'email' => '',
+                    'phone' => '0000000000',
+                ],
+                [
+                    'timed_spam' => true,
+                    'timed_spam_min' => 1,
+                ],
+                1
+            ],
+            'timed_spam_min_0_max_1' => [
+                [
+                    'email' => '',
+                    'phone' => '0000000000',
+                ],
+                [
+                    'timed_spam' => true,
+                    'timed_spam_min' => 0,
+                    'timed_spam_max' => 1,
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider provideValidationShouldFail
+     */
+    public function testValidationShouldFail($data, $formOptions, $sleep = 0, $expectedMessage = 'You are doing that too quickly'): void
+    {
+        $formBuilder = self::getContainer()->get('form.factory.custom')->createBuilder(FormType::class, null, $formOptions);
+        foreach (array_keys($data) as $key) {
+            $formBuilder->add($key);
+        }
+        $form = $formBuilder->getForm();
+        $form->createView();
+        if ($sleep > 0) {
+            sleep($sleep);
+        }
+        $form->submit($data);
+        $this->assertFalse($form->isValid());
+        $this->assertNotEmpty($form->getErrors());
+        $this->assertEquals($expectedMessage, $form->getErrors()->offsetGet(0)->getMessage());
+    }
+
+    public function provideValidationShouldFail(): array
+    {
+        return [
+            'timed_spam_min_1' => [
+                [
+                    'email' => 'foo@email.com',
+                    'phone' => '0000000000',
+                ],
+                [
+                    'timed_spam' => true,
+                    'timed_spam_min' => 1,
+                ]
+            ],
+            'timed_spam_max_0' => [
+                [
+                    'email' => 'foo@email.com',
+                    'phone' => '',
+                ],
+                [
+                    'timed_spam' => true,
+                    'timed_spam_max' => 0,
+                ]
+            ],
+            'timed_spam_max_1' => [
+                [
+                    'email' => 'foo@email.com',
+                    'phone' => '',
+                ],
+                [
+                    'timed_spam' => true,
+                    'timed_spam_max' => 1,
+                ],
+                1
+            ],
+            // Maybe this should rather throw an error during option resolution ?
+            'timed_spam_min_2_max_1' => [
+                [
+                    'email' => 'foo@email.com',
+                    'phone' => '',
+                ],
+                [
+                    'timed_spam' => true,
+                    'timed_spam_min' => 2,
+                    'timed_spam_max' => 1,
+                ]
+            ],
+            'timed_spam_with_error_message' => [
+                [
+                    'email' => 'foo@email.com',
+                    'phone' => '',
+                ],
+                [
+                    'timed_spam' => true,
+                    'timed_spam_min' => 1,
+                    'timed_spam_message' => 'Please wait 1 second before submitting',
+                ],
+                0,
+                'Please wait 1 second before submitting'
+            ],
+        ];
+    }
+}

--- a/tests/fixtures/TestKernel.php
+++ b/tests/fixtures/TestKernel.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Isometriks\Bundle\SpamBundle\Tests\fixtures;
+
+use Isometriks\Bundle\SpamBundle\IsometriksSpamBundle;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\HttpKernel\Kernel;
+
+class TestKernel extends Kernel
+{
+    use MicroKernelTrait;
+
+    public function __construct()
+    {
+        parent::__construct('test', true);
+    }
+
+    public function registerBundles(): iterable
+    {
+        return [
+            new FrameworkBundle(),
+            new IsometriksSpamBundle()
+        ];
+    }
+
+    protected function configureContainer(ContainerConfigurator $container, LoaderInterface $loader, ContainerBuilder $builder): void
+    {
+        $configDir = $this->getConfigDir();
+
+        if (is_file($configDir.'/services.yaml')) {
+            $container->import($configDir.'/services.yaml');
+            $container->import($configDir.'/{services}_'.$this->environment.'.yaml');
+        } else {
+            $container->import($configDir.'/{services}.php');
+        }
+
+        $builder->loadFromExtension('framework', [
+            'secret' => 'foo',
+            'test' => true,
+            'http_method_override' => true,
+            'handle_all_throwables' => true,
+            'php_errors' => [
+                'log' => true,
+            ],
+        ]);
+
+    }
+
+    public function getCacheDir(): string
+    {
+        return sys_get_temp_dir().'/cache'.spl_object_hash($this);
+    }
+
+    public function getLogDir(): string
+    {
+        return sys_get_temp_dir().'/logs'.spl_object_hash($this);
+    }
+
+    public function getProjectDir(): string
+    {
+        return __DIR__;
+    }
+}

--- a/tests/fixtures/config/services.yaml
+++ b/tests/fixtures/config/services.yaml
@@ -1,0 +1,5 @@
+services:
+  # Needed to make the form.factory public
+  form.factory.custom:
+    alias: 'form.factory'
+    public: true


### PR DESCRIPTION
Hello, I just discovered this bundle and I think it's a great tool easily to reduce spams in symfony apps. To make it easier to contribute I added a few tests.
If you think it's possible, I could also add github actions to run them automatically for each PR.